### PR TITLE
Downed Aircraft MVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## Version History
 
+### v1.6.0
+
+- :rocket: Significantly increased API Distance
+
 ### v1.5.0
 
 - :rocket: Migrate to ETL Base Library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## Version History
 
+### v1.7.0
+
+- :rocket: Add `domain` field to input values
+
 ### v1.6.0
 
 - :rocket: Significantly increased API Distance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "coe-adsbx",
     "type": "module",
     "prviate": true,
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "coe-adsbx",
     "type": "module",
     "prviate": true,
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/task.js
+++ b/task.js
@@ -69,7 +69,7 @@ export default class Task extends ETL {
         this.token = layer.data.environment.ADSBX_TOKEN;
         this.includes = layer.data.environment.ADSBX_INCLUDES;
 
-        this.api = 'https://adsbexchange.com/api/aircraft/v2/lat/42.0875/lon/-110.5905/dist/800/';
+        this.api = 'https://adsbexchange.com/api/aircraft/v2/lat/40.14401/lon/-119.81204/dist/2650/';
 
         const url = new URL(this.api);
         url.searchParams.append('apiKey', this.token);

--- a/task.js
+++ b/task.js
@@ -28,6 +28,11 @@ export default class Task extends ETL {
                     items: {
                         type: 'object',
                         properties: {
+                            domain: {
+                                type: 'string',
+                                description: 'Public Safety domain of the Aircraft'
+                                enum: [ 'EMS', 'FIRE', 'LAW' ]
+                            },
                             agency: {
                                 type: 'string',
                                 description: 'Agency in control of the Aircraft'
@@ -66,17 +71,16 @@ export default class Task extends ETL {
         if (!layer.data.environment.ADSBX_TOKEN) throw new Error('No ADSBX API Token Provided');
         if (!layer.data.environment.ADSBX_INCLUDES) layer.data.environment.ADSBX_INCLUDES = '[]';
 
-        this.token = layer.data.environment.ADSBX_TOKEN;
-        this.includes = layer.data.environment.ADSBX_INCLUDES;
+        const token = layer.data.environment.ADSBX_TOKEN;
+        const includes = layer.data.environment.ADSBX_INCLUDES;
+        const api = 'https://adsbexchange.com/api/aircraft/v2/lat/40.14401/lon/-119.81204/dist/2650/';
 
-        this.api = 'https://adsbexchange.com/api/aircraft/v2/lat/40.14401/lon/-119.81204/dist/2650/';
-
-        const url = new URL(this.api);
-        url.searchParams.append('apiKey', this.token);
+        const url = new URL(api);
+        url.searchParams.append('apiKey', token);
 
         const res = await fetch(url, {
             headers: {
-                'api-auth': this.token
+                'api-auth': token
             }
         });
 
@@ -123,7 +127,7 @@ export default class Task extends ETL {
         const fc = {
             type: 'FeatureCollection',
             features: features.filter((feat) => {
-                for (const include of this.includes) {
+                for (const include of includes) {
                     if (
                         (include.callsign && feat.properties.callsign.toLowerCase() === include.callsign.toLowerCase())
                         || (include.registration && feat.properties.registration.toLowerCase() === include.registration.toLowerCase())

--- a/task.js
+++ b/task.js
@@ -109,6 +109,17 @@ export default class Task extends ETL {
 
         console.log(`ok - fetched ${features.length} planes`);
 
+        const knownres = await fetch(new URL(`/api/layer/${this.etl.layer}/query`, this.etl.api), {
+            method: 'GET',
+            headers: {
+                Authorization: `bearer ${this.etl.token}`
+            }
+        });
+
+        const known = await knownres.json()
+
+        console.log(`ok - comparing against ${known.features.length} planes`);
+
         const fc = {
             type: 'FeatureCollection',
             features: features.filter((feat) => {

--- a/task.js
+++ b/task.js
@@ -44,10 +44,10 @@ export default class Task extends ETL {
                                 type: 'string',
                                 description: 'Type of Aircraft',
                                 enum: [
-                                    "HELICOPTER",
-                                    "FIXED WING"
+                                    'HELICOPTER',
+                                    'FIXED WING'
                                 ]
-                            },
+                            }
                         }
                     }
                 },
@@ -116,7 +116,7 @@ export default class Task extends ETL {
             }
         });
 
-        const known = await knownres.json()
+        const known = await knownres.json();
 
         console.log(`ok - comparing against ${known.features.length} planes`);
 


### PR DESCRIPTION
### Context

Add functionality to test for known aircraft and check against the list of ADSBX returned aircraft, generating a warning if the aircraft is no longer seen in the data.

- [ ] Add ability to filter by `before-stale` & `after-stale` in API
- [ ] Add cross check
- [ ] Mark as enemy aircraft or some other symbology if aircraft is missing/down