### PR TITLE
Extract more data from ADSBExchange API

### DIFF
--- a/task.ts
+++ b/task.ts
@@ -20,7 +20,7 @@ const Env = Type.Object({
     }),
     'ADSBX_TOKEN': Type.String({ description: 'API Token for ADSBExchange' }),
     'ADSBX_INCLUDES_FILTERING': Type.Boolean({
-        default: false
+        default: true
     }),
     'ADSBX_INCLUDES': Type.Array(Type.Object({
         domain: Type.String({

--- a/task.ts
+++ b/task.ts
@@ -20,7 +20,7 @@ const Env = Type.Object({
     }),
     'ADSBX_TOKEN': Type.String({ description: 'API Token for ADSBExchange' }),
     'ADSBX_INCLUDES_FILTERING': Type.Boolean({
-        default: true
+        default: false
     }),
     'ADSBX_INCLUDES': Type.Array(Type.Object({
         domain: Type.String({
@@ -193,7 +193,7 @@ export default class Task extends ETL {
                     speed: ac.gs * 0.514444 || 9999999.0,
                     course: ac.track || 9999999.0,
                     metadata: ac,
-                    remarks: 'Flight: ' + (ac.flight || '').trim() + ' - Registration: ' + (ac.r || '').trim() + ' - Type: ' + ac.t + ' - Category: ' + ac.category + ' - Emergency: ' + (ac.emergency || '').trim() + ' - Squawk: ' + (ac.squawk || '').trim(),
+                    remarks: 'Flight: ' + (ac.flight || 'Unknown').trim() + ' - Registration: ' + (ac.r || 'Unknown').trim() + ' - Type: ' + (ac.t || 'Unknown').trim() + ' - Category: ' + (ac.category || 'Unknown').trim() + ' - Emergency: ' + (ac.emergency || 'Unknown').trim() + ' - Squawk: ' + (ac.squawk || 'Unknown').trim(),
                 },
                 geometry: {
                     type: 'Point',

--- a/task.ts
+++ b/task.ts
@@ -149,7 +149,7 @@ export default class Task extends ETL {
             // https://www.adsbexchange.com/emitter-category-ads-b-do-260b-2-2-3-2-5-2/
             let ac_type = ''; // Unknown
             switch (ac.category) {
-                case 'A0':  // No ADS-B emitter category information. Still used for some airplanes. 
+                case 'A0':  // No ADS-B emitter category information. Still used for some airplanes.
                 case 'A1':  // Light (< 15500 lbs) fixed wing aircraft
                 case 'A2':  // Small (15500-75000 lbs) fixed wing aircraft
                 case 'A3':  // Large (75000 to 300000 lbs) fixed wing aircraft
@@ -193,7 +193,14 @@ export default class Task extends ETL {
                     speed: ac.gs * 0.514444 || 9999999.0,
                     course: ac.track || 9999999.0,
                     metadata: ac,
-                    remarks: 'Flight: ' + (ac.flight || 'Unknown').trim() + ' - Registration: ' + (ac.r || 'Unknown').trim() + ' - Type: ' + (ac.t || 'Unknown').trim() + ' - Category: ' + (ac.category || 'Unknown').trim() + ' - Emergency: ' + (ac.emergency || 'Unknown').trim() + ' - Squawk: ' + (ac.squawk || 'Unknown').trim(),
+                    remarks: [
+                        'Flight: ' + (ac.flight || 'Unknown').trim(),
+                        'Registration: ' + (ac.r || 'Unknown').trim(),
+                        'Type: ' + (ac.t || 'Unknown').trim(),
+                        'Category: ' + (ac.category || 'Unknown').trim(),
+                        'Emergency: ' + (ac.emergency || 'Unknown').trim(),
+                        'Squawk: ' + (ac.squawk || 'Unknown').trim(),
+                    ].join('\n')
                 },
                 geometry: {
                     type: 'Point',

--- a/task.ts
+++ b/task.ts
@@ -8,7 +8,7 @@ const Env = Type.Object({
         default: '40.14401,-119.81204'
     }),
     'Query Dist': Type.String({
-        description: 'Distance from the provided LatLon to provide results',
+        description: 'Distance from the provided Lat, Lon location in nautical miles (NM) to provide results',
         default: "2650"
     }),
     'ADSBX_API': Type.String({
@@ -71,12 +71,14 @@ const ADSBResponse = Type.Object({
     flight: Type.Optional(Type.String()),
     r: Type.Optional(Type.String()),
     t: Type.Optional(Type.String()),
+    dbFlags: Type.Optional(Type.Number()),
     alt_baro: Type.Optional(Type.Union([Type.Number(), Type.String()])),
     alt_geom: Type.Optional(Type.Number()),
     gs: Type.Optional(Type.Number()),
     track: Type.Optional(Type.Number()),
     baro_rate: Type.Optional(Type.Number()),
     squawk: Type.Optional(Type.String()),
+    emergency: Type.Optional(Type.String()),
     category: Type.Optional(Type.String()),
     nav_qnh: Type.Optional(Type.Number()),
     nav_altitude_mcp: Type.Optional(Type.Number()),
@@ -142,11 +144,48 @@ export default class Task extends ETL {
 
             if (!id.trim().length) continue;
 
+            // Determin the type of aircraft (fixed wing, rotorcraft, airship/balloon, etc.)
+            // https://www.adsbexchange.com/emitter-category-ads-b-do-260b-2-2-3-2-5-2/
+            var ac_type = ''; // Unknown
+            switch (ac.category) {
+                case 'A0':  // No ADS-B emitter category information. Still used for some airplanes. 
+                case 'A1':  // Light (< 15500 lbs) fixed wing aircraft
+                case 'A2':  // Small (15500-75000 lbs) fixed wing aircraft
+                case 'A3':  // Large (75000 to 300000 lbs) fixed wing aircraft
+                case 'A4':  // High vortex large (aircraft such as B-757) fixed wing aircraft
+                case 'A5':  // Heavy (> 300000 lbs) fixed wing aircraft
+                case 'A6':  // High performance (> 5g acceleration and 400 kts) fixed wing aircraft
+                    ac_type = '-F'; // Fixed Wing
+                    break;
+                case 'A7':
+                    ac_type = '-H'; // Rotorcraft – Any rotorcraft regardless of weight.
+                    break;
+                case 'B2':
+                    ac_type = '-L'; // Lighter-than-air – Any lighter than air (airship or balloon) regardless of weight.
+                    break;
+                default:
+                    break;
+            }
+
+            // Determine whether the aircraft is civilian or military
+            // https://www.adsbexchange.com/version-2-api-wip/
+            var ac_civmil = '-C'; // Civilian
+            if (ac.dbFlags !== undefined && ac.dbFlags % 2 !== 0) {
+                ac_civmil = '-M'; // Military
+            }
+
+            // Determine whether the aircraft is in emergency mode (show in red aka. "hostile") or not
+            // https://www.adsbexchange.com/version-2-api-wip/
+            var ac_emergency = '-f'; // Normal
+            if (ac.emergency !== 'none') {
+                ac_emergency = '-h'; // Emergency
+            }
+
             ids.set(id, {
                 id: id,
                 type: 'Feature',
                 properties: {
-                    type: 'a-f-A',
+                    type: 'a' + ac_emergency + '-A' + ac_civmil + ac_type,
                     callsign: (ac.flight || '').trim(),
                     time: new Date(),
                     start: new Date(),

--- a/task.ts
+++ b/task.ts
@@ -177,7 +177,7 @@ export default class Task extends ETL {
             // Determine whether the aircraft is in emergency mode (show in red aka. "hostile") or not
             // https://www.adsbexchange.com/version-2-api-wip/
             var ac_emergency = '-f'; // Normal
-            if (ac.emergency !== 'none') {
+            if (ac.emergency !== undefined && ac.emergency !== 'none') {
                 ac_emergency = '-h'; // Emergency
             }
 


### PR DESCRIPTION
Extracts additional data from the ADSBExchange API and uses it to style the CoT:

* **Fixed wing vs helicopter vs blimp/balloon**: Identifies aircraft type based on the "category" field

* **Military vs Civilian plane**: Identifies military vs civilian planes based on the "dbFlags" value. 

* **Planes squawking an emergency code**: Identifies planes in emergency mode via the "emergency" flag and colors the icon red by flagging it as "hostile" in CoT. 

Fixes #6 and partially #5.